### PR TITLE
task: Revise session creation and teardown

### DIFF
--- a/matching/app/app.py
+++ b/matching/app/app.py
@@ -28,6 +28,7 @@ def cleanup(resp_or_exc):
 	This decorator function ensures that Sessions are removed at the end of a request.
 
 	References:
-	- 
+	- https://docs.sqlalchemy.org/en/13/orm/contextual.html#using-thread-local-scope-with-web-applications
+	- https://dev.to/nestedsoftware/flask-and-sqlalchemy-without-the-flask-sqlalchemy-extension-3cf8
     '''
     Session.remove()

--- a/matching/app/app.py
+++ b/matching/app/app.py
@@ -7,6 +7,7 @@ from flask_restful import Api
 
 from matching.api import ComputeMatch
 from matching.config import ConfigurationFactory
+from matching.database import Session
 
 app = Flask(__name__)
 app.config.from_object(ConfigurationFactory.from_env())
@@ -15,7 +16,18 @@ api = Api(app)
 api.add_resource(ComputeMatch, '/compute-match')
 
 @app.teardown_appcontext
-def close_db_session(error):
-    """Closes the database session at the end of the request."""
-    if hasattr(g, 'mci_db_session'):
-        g.mci_db_session.remove()
+def cleanup(resp_or_exc):
+    '''
+    A session establishes all conversations with the database. 
+    Mainly, it requests a connection with the database. 
+    
+    A session can have a lifespan across many *short* transactions. For web applications, 
+	the scope of a session should align with the scope of a request. 
+	In other words: tear down the session at the end of a request.
+
+	This decorator function ensures that Sessions are removed at the end of a request.
+
+	References:
+	- 
+    '''
+    Session.remove()

--- a/matching/common/util.py
+++ b/matching/common/util.py
@@ -2,7 +2,7 @@ from itertools import combinations
 
 from sqlalchemy import String, cast
 
-from matching.database import init_individual_table, init_db_session
+from matching.database import init_individual_table, Session
 
 def filter_on_ssn(combo, potential_matches, individual_table):
     '''
@@ -37,7 +37,6 @@ def compute_match_with_score(individual_args: dict):
 
     :returns: an Individual and a score of the match likelihood (or None) 
     '''
-    session = init_db_session()
     individual_table = init_individual_table()
     mci_id = ''
     score = ''
@@ -61,7 +60,7 @@ def compute_match_with_score(individual_args: dict):
         'gender_id': 0.05,
     }
 
-    potential_matches = session.query(individual_table).filter_by(
+    potential_matches = Session.query(individual_table).filter_by(
         last_name=individual_args['last_name'],
         date_of_birth=individual_args['date_of_birth']
     )

--- a/matching/config/__init__.py
+++ b/matching/config/__init__.py
@@ -1,1 +1,1 @@
-from matching.config.config import Config, ConfigurationFactory
+from matching.config.config import Config, ConfigurationFactory, TestConfig

--- a/matching/config/config.py
+++ b/matching/config/config.py
@@ -81,6 +81,6 @@ class ConfigurationFactory(object):
         Returns:
             object: Configuration object based on the configuration environment found in the `APP_ENV` environment variable.
         """
-        environment = os.getenv('APP_ENV', 'DEVELOPMENT')
+        environment = os.getenv('APP_ENV', 'TEST')
 
         return ConfigurationFactory.get_config(environment)

--- a/matching/database.py
+++ b/matching/database.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from flask_sqlalchemy import SQLAlchemy
 from flask import g
 from sqlalchemy import MetaData, Table, create_engine
@@ -7,25 +8,17 @@ from matching.config import ConfigurationFactory
 
 config = ConfigurationFactory.from_env()
 engine = create_engine(config.SQLALCHEMY_DATABASE_URI)
+Session = scoped_session(sessionmaker(bind=engine))
 
 def init_individual_table():
-    # Instantiate a Table with Metadata
-    # http://flask.pocoo.org/docs/1.0/patterns/sqlalchemy/#sql-abstraction-layer
-    # https://docs.sqlalchemy.org/en/13/core/metadata.html
+    '''
+    This function abstracts a Table with Individual metadata from the MCI database.
+
+    References:
+    - http://flask.pocoo.org/docs/1.0/patterns/sqlalchemy/#sql-abstraction-layer
+    - https://docs.sqlalchemy.org/en/13/core/metadata.html
+    '''
     metadata = MetaData(bind=engine)
     individual = Table('individual', metadata, autoload=True)
 
     return individual
-
-def init_db_session():
-    # https://docs.sqlalchemy.org/en/13/orm/contextual.html#using-thread-local-scope-with-web-applications
-    # Pass the engine to the sessionmaker (a factory for creating sessions, 
-    # i.e., a object that manages interactions with the database) 
-    # https://docs.sqlalchemy.org/en/13/orm/session_basics.html#what-does-the-session-do
-    Session = scoped_session(sessionmaker(bind=engine))
-    # Register the session
-    Session()
-    # Add session to "g"
-    g.mci_db_session = Session
-
-    return Session

--- a/matching/database.py
+++ b/matching/database.py
@@ -1,6 +1,3 @@
-from contextlib import contextmanager
-from flask_sqlalchemy import SQLAlchemy
-from flask import g
 from sqlalchemy import MetaData, Table, create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
@@ -18,6 +15,7 @@ def init_individual_table():
     - http://flask.pocoo.org/docs/1.0/patterns/sqlalchemy/#sql-abstraction-layer
     - https://docs.sqlalchemy.org/en/13/core/metadata.html
     '''
+
     metadata = MetaData(bind=engine)
     individual = Table('individual', metadata, autoload=True)
 


### PR DESCRIPTION
This PR refactors my approach to Session management. The approach:

1. declares a scoped_session in the application's global scope: https://dev.to/nestedsoftware/flask-and-sqlalchemy-without-the-flask-sqlalchemy-extension-3cf8

2. tears down the Session at the end of a request: https://docs.sqlalchemy.org/en/13/orm/contextual.html#using-thread-local-scope-with-web-applications and https://dev.to/nestedsoftware/flask-and-sqlalchemy-without-the-flask-sqlalchemy-extension-3cf8

